### PR TITLE
Add Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ export interface EufySecurityConfig {
     persistentDir?: string;                 // Directory in which the persistent information is saved (default: module path)
     p2pConnectionSetup: number;             // P2P connection setup (default: 0 ; Prefers local connection over cloud)
     pollingIntervalMinutes: number;         // Polling intervall for data refresh from Eufy Cloud (default: 10 min.)
-    eventDurationSeconds: number;           // Duration in seconds befora an event is reset E.g. motion event (default: 10 sec.)
+    eventDurationSeconds: number;           // Duration in seconds before an event is reset E.g. motion event (default: 10 sec.)
 }
 ```
 
@@ -627,3 +627,30 @@ In an attempt to keep compatibility between different server and client versions
 ## Authentication
 
 eufy-security-ws does not handle authentication and allows all connections to the websocket API. If you want to add authentication, add authentication middleware to your Express instance or run NGINX in front of Express instance.
+
+## Docker
+
+eufy-security-ws is available via a Docker image
+([`bropat/eufy-security-ws`](https://hub.docker.com/r/bropat/eufy-security-ws)). It is configured by a handful of environment variables that correspond to the options found in the config file above:
+
+* `USERNAME:` Eufy Account Username (required)
+* `PASSWORD:` Eufy Account Password (required)
+* `COUNTRY:` ISO 3166-1 Alpha-2 country code (default: US)
+* `LANGUAGE:` ISO 639 language code (default: en)
+* `TRUSTED_DEVICE_NAME:` Label of the trusted devices (viewable with 2fa activated in Eufy App; default: eufyclient)
+* `EVENT_DURATION_SECONDS:` Duration in seconds before an event is reset E.g. motion event (default: 10 sec.)
+* `P2P_CONNECTION_SETUP:` P2P connection setup (default: 0 ; Prefers local connection over cloud)
+* `POLLING_INTERVAL_MINUTES:` Polling intervall for data refresh from Eufy Cloud (default: 10 min.)
+
+The image also exposes a `/data` volume that corresponds to the `persistentDir`.
+
+Running the image is straightforward:
+
+```
+docker run -it \
+    -e USERNAME=user \
+    -e PASSWORD=password \
+    -v "$(PWD)"/data:/data \
+    -p 3000:0000 \
+    bropat/eufy-security-ws:latest
+```

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,5 @@
+*.md
+Dockerfile
+LICENSE
+img
+tsconfig.tsbuildinfo

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:14-alpine as build
+WORKDIR /tmp
+COPY . .
+RUN npm ci && npm run build
+
+FROM node:14-alpine
+WORKDIR /usr/src/app
+COPY --from=build /tmp/dist ./dist
+COPY --from=build /tmp/docker/run.sh ./run.sh
+COPY --from=build /tmp/package.json ./package.json
+COPY --from=build /tmp/package-lock.json ./package-lock.json
+RUN apk add --no-cache jq=1.6-r0 \
+  && npm ci --only=production
+EXPOSE 3000
+VOLUME ["/data"]
+CMD [ "/usr/src/app/run.sh" ]

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+if [ -z "${USERNAME}" ] || [ -z "${PASSWORD}" ]; then
+    echo "Missing one of USERNAME or PASSWORD"
+    exit 1
+fi
+
+COUNTRY="${COUNTRY:-US}"
+EVENT_DURATION_SECONDS="${EVENT_DURATION_SECONDS:-10}"
+LANGUAGE="${LANGUAGE:-en}"
+P2P_CONNECTION_SETUP="${P2P_CONNECTION_SETUP:-0}"
+POLLING_INTERVAL_MINUTES="${POLLING_INTERVAL_MINUTES:-10}"
+TRUSTED_DEVICE_NAME="${TRUSTED_DEVICE_NAME:-eufyclient}"
+
+JSON_STRING="$( jq -n \
+  --arg username "$USERNAME" \
+  --arg password "$PASSWORD" \
+  --arg country "$COUNTRY"  \
+  --arg event_duration_seconds "$EVENT_DURATION_SECONDS"  \
+  --arg language "$LANGUAGE"  \
+  --arg p2p_connection_setup "$P2P_CONNECTION_SETUP"  \
+  --arg polling_interval_minutes "$POLLING_INTERVAL_MINUTES"  \
+  --arg trusted_device_name "$TRUSTED_DEVICE_NAME"  \
+    '{
+      country: $country,
+      eventDurationSeconds: $event_duration_seconds,
+      language: $language,
+      p2pConnectionSetup: $p2p_connection_setup,
+      password: $password,
+      persistentDir: "/data",
+      pollingIntervalMinutes: $polling_interval_minutes,
+      trustedDeviceName: $trusted_device_name,
+      username: $username,
+    }'
+  )"
+
+echo "$JSON_STRING" > /etc/eufy-security-ws-config.json
+/usr/local/bin/node /usr/src/app/dist/bin/server.js --config /etc/eufy-security-ws-config.json


### PR DESCRIPTION
This PR adds support for a Docker image of the library. It includes updates to the README.

Once we merge this in, we can start on automatically pushing Docker images to Docker Hub (and GitHub Container Registry if we find that necessary). @bropat, do you have a Docker Hub account already? Could you create a `bropat/eufy-security-ws` repo there and invite me to it as a collaborator?