### PR TITLE
Add GitHub Action to push new Docker Hub images

### DIFF
--- a/.github/workflows/publish_to_docker_hub.yaml
+++ b/.github/workflows/publish_to_docker_hub.yaml
@@ -1,0 +1,66 @@
+---
+name: "Publish to Docker Hub"
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "*"
+
+jobs:
+  publish_to_docker_hub:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Prepare
+        id: prep
+        run: |
+          DOCKER_IMAGE=bropat/eufy-security-ws
+          VERSION=noop
+
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          elif [[ $GITHUB_REF == refs/heads/dev ]]; then
+            VERSION=dev
+          elif [[ $GITHUB_REF == refs/heads/master ]]; then
+            VERSION=latest
+          fi
+
+          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+            MINOR=${VERSION%.*}
+            MAJOR=${MINOR%.*}
+            TAGS="$TAGS,${DOCKER_IMAGE}:${MINOR},${DOCKER_IMAGE}:${MAJOR},${DOCKER_IMAGE}:latest"
+          fi
+
+          echo ::set-output name=version::${VERSION}
+          echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
+          push: true
+          tags: ${{ steps.prep.outputs.tags }}


### PR DESCRIPTION
This PR creates a GitHub action that pushes `master` and tagged commits to Docker Hub as images. Unlike the automated "watcher" inside of Docker Hub, this approach ensures multi-arch images are created, as well, which will allow ARM users to use the image. It requires that `DOCKER_HUB_USERNAME` and `DOCKER_HUB_TOKEN` secrets exist in this repo.

@bropat Thoughts?