### PR TITLE
Hostname setting patch and defaulting it to localhost

### DIFF
--- a/src/bin/server.ts
+++ b/src/bin/server.ts
@@ -11,6 +11,7 @@ const program = new Command();
 program
     .addOption(new Option("-c, --config <file>", "Configuration file").default("config.json", "looks in current directory"))
     .addOption(new Option("-p, --port <port>", "Listening port").default(3000))
+    .addOption(new Option("-h, --host <host>", "Listening Host").default("localhost"))
     .addOption(new Option("-v, --verbose"))
     .addOption(new Option("-q, --quiet"));
 
@@ -61,7 +62,7 @@ const args = program.opts();
     let server: EufySecurityServer;
 
     try {
-        server = new EufySecurityServer(driver, { port: args.port, logger: logger });
+        server = new EufySecurityServer(driver, { port: args.port, host: args.host, logger: logger });
         await server.start();
     } catch (error) {
         logger.error("Unable to start Server", error);

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -334,13 +334,13 @@ export class  EufySecurityServer extends EventEmitter {
         this.sockets = new ClientsController(this.driver, this.logger);
         this.wsServer.on("connection", (socket, request) => this.sockets?.addSocket(socket, request));
 
-        this.logger.debug(`Starting server on port ${this.options.port}`);
+        this.logger.debug(`Starting server on host ${this.options.host}, port ${this.options.port}`);
 
         this.server.on("error", this.onError.bind(this));
-        this.server.listen(this.options.port);
+        this.server.listen(this.options.port, this.options.host);
         await once(this.server, "listening");
         this.emit("listening");
-        this.logger.info(`Eufy Security server listening on port ${this.options.port}`);
+        this.logger.info(`Eufy Security server listening on host ${this.options.host}, port ${this.options.port}`);
         this.driver.connect();
     }
 


### PR DESCRIPTION
This patch adds the possibility to define the hostname that the server listens on via a command line parameter "--host" and defaults it to localhost instead of the current 0.0.0.0. Fixes part 1 of bropat/eufy-security-ws#66