### PR TITLE
All .sh files to LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Declare files that will always have LF line endings on checkout.
+*.sh text eol=lf


### PR DESCRIPTION
Added a .gitattributes file so that all script files (.sh) automatically get the LF line ending instead of the setting the user specified.

The docker image has to be rebuilt though, so you can do it manually or wait for @bropat to update the docker image

If there is another way of me being able to update the docker image, let me know!