### PR TITLE
Fix for container not stopping gracefully

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -129,4 +129,4 @@ JSON_STRING="$( jq -n \
   )"
 
 echo "$JSON_STRING" > /dev/shm/eufy-security-ws-config.json
-/usr/local/bin/node /usr/src/app/dist/bin/server.js --host 0.0.0.0 --config /dev/shm/eufy-security-ws-config.json $DEBUG_OPTION $PORT_OPTION
+exec /usr/local/bin/node /usr/src/app/dist/bin/server.js --host 0.0.0.0 --config /dev/shm/eufy-security-ws-config.json $DEBUG_OPTION $PORT_OPTION


### PR DESCRIPTION
Fixes the container being unable to stop because of the SIGTERM signal not propogating. See issue https://github.com/bropat/eufy-security-ws/issues/201 for more info.