### PR TITLE
Support docker secrets for username and password

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# allow setting specific environment variables with docker secrets
+# the format is <variable-name>_FILE
+supportedSecrets=( "USERNAME" 
+                   "PASSWORD"
+                  )
+for secret in ${supportedSecrets[@]}; do
+    envFile="${secret}_FILE"
+    if [ $(printenv ${envFile}) ]; then envFileName=`printenv ${envFile}`; fi
+    if [[ ${!envFile} && -f "$envFileName" ]]; then
+        val=`cat $envFileName`
+        export "${secret}"="$val"
+        echo "${secret} environment variable was set by secret ${envFile}"
+    fi
+done
+
 if [ -z "${USERNAME}" ] || [ -z "${PASSWORD}" ]; then
     echo "Missing one of USERNAME or PASSWORD"
     exit 1


### PR DESCRIPTION
I don't like confidential data just hanging around in environment variables, especially for security related products. That's what docker secrets were made for to make things a bit better.

With this PR you can use docker secrets to set the `USERNAME` and `PASSWORD` using `USERNAME_FILE` and `PASSWORD_FILE` respectively. The files just contain the plaintext username or password. The traditional way of just using `USERNAME` and/or `PASSWORD` still works.

A full docker compose example:

`docker-compose.yml`
```yaml
secrets:
  eufy-security-ws_password:
    file: <secretsmount>/eufy-security-ws_password
  eufy-security-ws_username:
    file: <secretsmount>/eufy-security-ws_username

services:
  eufy-security-ws:
    image: bropat/eufy-security-ws:latest
    container_name: eufy-security-ws
    network_mode: host
    volumes:
      - ./data:/data
    environment:
      USERNAME_FILE: /run/secrets/eufy-security-ws_username
      PASSWORD_FILE: /run/secrets/eufy-security-ws_password
    secrets:
      - eufy-security-ws_username
      - eufy-security-ws_password
```

`$ cat eufy-security-ws_username` as an example
```
emailaddress@example.com
```