### PR TITLE
use docker/metadata-action for docker tag generation

### DIFF
--- a/.github/workflows/publish_to_docker_hub.yaml
+++ b/.github/workflows/publish_to_docker_hub.yaml
@@ -17,28 +17,17 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
-      - name: Prepare
-        id: prep
-        run: |
-          DOCKER_IMAGE=bropat/eufy-security-ws
-          VERSION=noop
-
-          if [[ $GITHUB_REF == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/}
-          elif [[ $GITHUB_REF == refs/heads/dev ]]; then
-            VERSION=dev
-          elif [[ $GITHUB_REF == refs/heads/master ]]; then
-            VERSION=latest
-          fi
-
-          TAGS="${DOCKER_IMAGE}:${VERSION}"
-          if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-            MINOR=${VERSION%.*}
-            MAJOR=${MINOR%.*}
-            TAGS="$TAGS,${DOCKER_IMAGE}:${MINOR},${DOCKER_IMAGE}:${MAJOR},${DOCKER_IMAGE}:latest"
-          fi
-
-          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+      - name: Docker meta
+        uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: |
+            bropat/eufy-security-ws
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -61,4 +50,4 @@ jobs:
           file: ./docker/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ steps.prep.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
I've recently found that the docker `latest` tag doesn't refer to the latest semver tag. This is unexpected behavior.

This PR uses the `docker/metadata-action` to generate the docker tags in a way that is in line with the best practices.

- `latest` always refers to the last published version
- `master` and `develop` tags are used for the latest updates on each of these branches
- Multiple [SemVer tags](https://medium.com/@mccode/using-semantic-versioning-for-docker-image-tags-dfde8be06699) are created for each version as indicated by the following image:

![](https://miro.medium.com/v2/resize:fit:4800/format:webp/1*crt6mWe_B_I1WpQEAOndUQ@2x.jpeg)


To see the tags produced by the changes introduced in this PR I've kicked off a test workflow [here](https://github.com/RoboMagus/eufy-security-ws/actions/runs/14357644313/job/40250746385) (Look at the `Docker meta` step and expand the `docker tags` sub item to see the resulting tags).