### PR TITLE
Ensure dev simulate the same as npm package

### DIFF
--- a/docker/run_dev.sh
+++ b/docker/run_dev.sh
@@ -180,6 +180,8 @@ if [ -n "${EUFY_CLIENT_GIT_URL}" ] && [ -n "${EUFY_CLIENT_GIT_BRANCH}" ];  then
     npm i
     npm run prepublishOnly -y
     mv build /usr/src/app/node_modules/eufy-security-client/build
+    cp package.json /usr/src/app/node_modules/eufy-security-client/build/
+    rm -r /tmp/eufy-security-client
 fi
 
 echo "$JSON_STRING" > /dev/shm/eufy-security-ws-config.json


### PR DESCRIPTION
Was missing the package.json in the build when built from github, just to ensure it is the same behaviour as installed.