### PR TITLE
feat: re-enable station.get_camera_info and station.get_storage_info

### DIFF
--- a/src/lib/station/command.ts
+++ b/src/lib/station/command.ts
@@ -5,6 +5,8 @@ export enum StationCommand {
   disconnect = "station.disconnect",
   getPropertiesMetadata = "station.get_properties_metadata",
   getProperties = "station.get_properties",
+  getCameraInfo = "station.get_camera_info",
+  getStorageInfo = "station.get_storage_info",
   setProperty = "station.set_property",
   hasProperty = "station.has_property",
   triggerAlarm = "station.trigger_alarm",

--- a/src/lib/station/incoming_message.ts
+++ b/src/lib/station/incoming_message.ts
@@ -42,6 +42,14 @@ export interface IncomingCommandGetProperties extends IncomingCommandStationBase
   command: StationCommand.getProperties;
 }
 
+export interface IncomingCommandGetCameraInfo extends IncomingCommandStationBase {
+  command: StationCommand.getCameraInfo;
+}
+
+export interface IncomingCommandGetStorageInfo extends IncomingCommandStationBase {
+  command: StationCommand.getStorageInfo;
+}
+
 export interface IncomingCommandSetProperty extends IncomingCommandStationBase {
   command: StationCommand.setProperty;
   name: string;
@@ -124,6 +132,8 @@ export type IncomingMessageStation =
   | IncomingCommandDisconnect
   | IncomingCommandGetPropertiesMetadata
   | IncomingCommandGetProperties
+  | IncomingCommandGetCameraInfo
+  | IncomingCommandGetStorageInfo
   | IncomingCommandSetProperty
   | IncomingCommandTriggerAlarm
   | IncomingCommandResetAlarm

--- a/src/lib/station/message_handler.ts
+++ b/src/lib/station/message_handler.ts
@@ -66,16 +66,12 @@ export class StationMessageHandler {
           throw new UnknownCommandError(command);
         }
       }
-      /*case StationCommand.getCameraInfo:
-                await station.getCameraInfo().catch((error) => {
-                    throw error;
-                });
-                return client.schemaVersion >= 13 ? { async: true } : {};
-            case StationCommand.getStorageInfo:
-                await station.getStorageInfo().catch((error) => {
-                    throw error;
-                });
-                return client.schemaVersion >= 13 ? { async: true } : {};*/
+      case StationCommand.getCameraInfo:
+        await station.getCameraInfo();
+        return client.schemaVersion >= 13 ? { async: true } : {};
+      case StationCommand.getStorageInfo:
+        await station.getStorageInfoEx();
+        return client.schemaVersion >= 13 ? { async: true } : {};
       case StationCommand.connect:
         await station.connect().catch((error) => {
           throw error;

--- a/src/lib/station/outgoing_message.ts
+++ b/src/lib/station/outgoing_message.ts
@@ -16,6 +16,8 @@ export interface StationResultTypes {
     serialNumber?: string;
     properties: Record<string, unknown>;
   };
+  [StationCommand.getCameraInfo]: { async?: boolean };
+  [StationCommand.getStorageInfo]: { async?: boolean };
   [StationCommand.setProperty]: { async?: boolean };
   [StationCommand.triggerAlarm]: { async?: boolean };
   [StationCommand.resetAlarm]: { async?: boolean };


### PR DESCRIPTION
## Problem

The bridge already wires `station.getCameraInfo()` from `eufy-security-client` and registers the resulting `raw device property changed` events; only the WebSocket dispatch is commented out. Consumers (HA addon, dashboards, …) currently have no way to ask the HomeBase 3 for the live cam-state snapshot of all paired cams.

`src/lib/station/message_handler.ts` (current trunk):

```ts
/*case StationCommand.getCameraInfo:
    await station.getCameraInfo().catch((error) => { throw error; });
    return client.schemaVersion >= 13 ? { async: true } : {};
case StationCommand.getStorageInfo:
    await station.getStorageInfo().catch((error) => { throw error; });
    return client.schemaVersion >= 13 ? { async: true } : {};*/
```

That snapshot is the only path that keeps the master `enabled` flag in sync with the iOS Eufy app for sleeping akku-cams: the cloud catalog `device_list` endpoint that `driver.poll_refresh` hits never refreshes `enabled` for outdoor PT cams (S4 etc.), but `getCameraInfo()` returns `param_type = CMD_INDOOR_ENABLE_PRIVACY_MODE_S350` (6250) per cam channel, and the lib already dispatches that into `device.updateRawProperties`.

## Fix

Re-enable both dispatches and re-add the missing enum members in `command.ts`. The schema-version check stays consistent with the rest of the file — `>= 13` returns `async: true`, older clients get an empty object.

## Why now

This pairs with two `eufy-security-client` bug-fix PRs for S4 / outdoor PT cam enabled-state reads (bropat/eufy-security-client#873 and bropat/eufy-security-client#874). With those merged but `getCameraInfo` still WS-private, the only way for a downstream to surface live `enabled` state is to call `driver.poll_refresh` and hope the cloud catalog has caught up — which it does not for sleeping akku-cams. Exposing `getCameraInfo` lets the dashboard / HA addon ask the HomeBase 3 directly.

## Verified on

- `eufy-security-ws` 2.1.0
- `eufy-security-client` 3.8.0 with the two pending bug-fix PRs applied
- HomeBase 3 (`T8030`) + eufyCam S4 (`T8172`): a single `station.get_camera_info` round-trip pulls fresh `enabled` per cam, matching what the iOS Eufy app shows.