### PR TITLE
fix(eslint): wire up eslint-config-prettier to silence formatting-rule noise

### DIFF
--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -1,5 +1,6 @@
 import tseslint from "typescript-eslint";
 import { defineConfig } from "eslint/config";
+import eslintConfigPrettier from "eslint-config-prettier";
 
 export default defineConfig([
     tseslint.configs.recommended,
@@ -33,24 +34,8 @@ export default defineConfig([
             "no-empty": "off",
             "no-useless-escape": "off",
             "no-fallthrough": "off",
-            "indent": [
-                "error",
-                4,
-                {
-                    "SwitchCase": 1
-                }
-            ],
-            "quotes": [
-                "error",
-                "double",
-                {
-                    "avoidEscape": true,
-                    "allowTemplateLiterals": true
-                }
-            ],
             "no-var": "error",
             "prefer-const": "error",
-            "no-trailing-spaces": "error",
         },
         languageOptions : {
             ecmaVersion: 5,
@@ -62,6 +47,7 @@ export default defineConfig([
             "@typescript-eslint/explicit-function-return-type": "off"
         },
     },
+    eslintConfigPrettier,
     {
         ignores: ["./dist/**"],
     }


### PR DESCRIPTION
## Context

Follow-up to #548 — @max246 asked for a separate PR fixing the ESLint situation. The npm-install ERESOLVE part is already handled by #553; this PR fixes the *other* half: the config inside the repo.

## Problem

`eslint-config-prettier@^10.1.8` is in `devDependencies` but never imported by `eslint.config.mts`. As a result the `indent` / `quotes` / `no-trailing-spaces` rules fight Prettier — the codebase is 2-space (Prettier default), ESLint requires 4-space — and CI reports **7485 problems** on every push to `develop`. The `continue-on-error: true` keeps the job green, but the SARIF report makes the Security tab unusable.

## Fix

- Import `eslintConfigPrettier` and append it as the last config entry so it disables every formatting rule that conflicts with Prettier.
- Drop the now-redundant `indent`, `quotes`, `no-trailing-spaces` overrides (eslint-config-prettier would disable them anyway).

## Verification

Locally with Node 24:

| | Before | After |
|---|---:|---:|
| `npx eslint .` problems | 7485 | 72 |

The 72 remaining are pre-existing `no-explicit-any` findings inside `src/**/__test__/*.test.tsx`. They fall outside the project's rule overrides because the `files:` glob covers `ts/mts/cts/mjs/cjs` but not `tsx`. Untouched here — happy to address in a separate PR if you want the test-file overrides extended.