### PR TITLE
Fix node24 PKCS1 failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,16 @@ To try it out or for more information, such as API documentation, Docker image, 
 
 Instructions aimed at maintainers for deploying a new version: [Deployment](docs/deployment.md)
 
-### Security warning `CVE-2023-46809`
+### `RSA_PKCS1_PADDING` / CVE-2023-46809
 
-When starting the Docker container, you may see a log line:
+The Eufy cloud handshake requires `RSA_PKCS1_PADDING`, which Node.js restricted as part of the
+Marvin attack fix (CVE-2023-46809). Earlier versions worked around this by launching Node with
+`--security-revert=CVE-2023-46809`, but that flag is no longer recognized on Node 24+ and causes
+Node to abort on startup (`Error: Attempt to revert an unknown CVE`).
 
-    SECURITY WARNING: Reverting CVE-2023-46809: Marvin attack on PKCS#1 padding
-
-This is expected and can be safely ignored, as the Eufy client still requires `RSA_PKCS1_PADDING` for cloud decryption. No code or runtime behavior is changed.
+This is now handled by `eufy-security-client`'s embedded (pure-JS) PKCS#1 implementation, which is
+enabled by default (`enableEmbeddedPKCS1Support: true`). No Node flag is required and you no longer
+need to set anything. To opt out, set `"enableEmbeddedPKCS1Support": false` in your config file.
 
 
 ## Changelog

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -143,33 +143,5 @@ JSON_STRING="$( jq -n \
     }"
   )"
 
-check_version() {
-    if [ "$1" = "$2" ]; then
-        return 1 # equal
-    fi
-    version=$(printf '%s\n' "$1" "$2" | sort -V | tail -n 1)
-    if [ "$version" = "$2" ]; then
-        return 2 # greater
-    fi
-    return 0 # lower
-}
-
-node_version=$(node -v)
-node_result=0
-if [ "${node_version:1:2}" = "18" ]; then
-    check_version "v18.19.1" "$node_version"
-    node_result=$?
-elif [ "${node_version:1:2}" = "20" ]; then
-    check_version "v20.11.1" "$node_version"
-    node_result=$?
-else
-    check_version "v21.6.2" "$node_version"
-    node_result=$?
-fi
-WORKAROUND_ISSUE_310=""
-if [ $node_result -gt 0 ] ; then
-    WORKAROUND_ISSUE_310="--security-revert=CVE-2023-46809"
-fi
-
 echo "$JSON_STRING" > /dev/shm/eufy-security-ws-config.json
-exec /usr/local/bin/node $WORKAROUND_ISSUE_310 /usr/src/app/dist/bin/server.js --host 0.0.0.0 --config /dev/shm/eufy-security-ws-config.json $DEBUG_OPTION $PORT_OPTION
+exec /usr/local/bin/node /usr/src/app/dist/bin/server.js --host 0.0.0.0 --config /dev/shm/eufy-security-ws-config.json $DEBUG_OPTION $PORT_OPTION

--- a/docker/run_dev.sh
+++ b/docker/run_dev.sh
@@ -143,34 +143,6 @@ JSON_STRING="$( jq -n \
     }"
   )"
 
-check_version() {
-    if [ "$1" = "$2" ]; then
-        return 1 # equal
-    fi
-    version=$(printf '%s\n' "$1" "$2" | sort -V | tail -n 1)
-    if [ "$version" = "$2" ]; then
-        return 2 # greater
-    fi
-    return 0 # lower
-}
-
-node_version=$(node -v)
-node_result=0
-if [ "${node_version:1:2}" = "18" ]; then
-    check_version "v18.19.1" "$node_version"
-    node_result=$?
-elif [ "${node_version:1:2}" = "20" ]; then
-    check_version "v20.11.1" "$node_version"
-    node_result=$?
-else
-    check_version "v21.6.2" "$node_version"
-    node_result=$?
-fi
-WORKAROUND_ISSUE_310=""
-if [ $node_result -gt 0 ] ; then
-    WORKAROUND_ISSUE_310="--security-revert=CVE-2023-46809"
-fi
-
 if [ -n "${EUFY_CLIENT_GIT_URL}" ] && [ -n "${EUFY_CLIENT_GIT_BRANCH}" ];  then
     echo "Installing a git version of Eufy Client $EUFY_CLIENT_GIT_URL with branch $EUFY_CLIENT_GIT_BRANCH"
     npm uninstall --force eufy-security-client
@@ -187,4 +159,4 @@ if [ -n "${EUFY_CLIENT_GIT_URL}" ] && [ -n "${EUFY_CLIENT_GIT_BRANCH}" ];  then
 fi
 
 echo "$JSON_STRING" > /dev/shm/eufy-security-ws-config.json
-exec /usr/local/bin/node $WORKAROUND_ISSUE_310 /usr/src/app/dist/bin/server.js --host 0.0.0.0 --config /dev/shm/eufy-security-ws-config.json $DEBUG_OPTION $PORT_OPTION
+exec /usr/local/bin/node /usr/src/app/dist/bin/server.js --host 0.0.0.0 --config /dev/shm/eufy-security-ws-config.json $DEBUG_OPTION $PORT_OPTION

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -46,13 +46,16 @@ docker run -it \
     bropat/eufy-security-ws:latest
 ```
 
-### Security warning regarding CVE-2023-46809
+### `RSA_PKCS1_PADDING` / CVE-2023-46809
 
-When starting the Docker container, you may see the following log line:
+The Eufy cloud handshake requires `RSA_PKCS1_PADDING`, which Node.js restricted as part of the
+Marvin attack fix (CVE-2023-46809). Earlier images worked around this by launching Node with
+`--security-revert=CVE-2023-46809`, but that flag is no longer recognized on Node 24+ and makes the
+container exit immediately on startup with `Error: Attempt to revert an unknown CVE [CVE-2023-46809]`
+(exit code 12).
 
-    SECURITY WARNING: Reverting CVE-2023-46809: Marvin attack on PKCS#1 padding
-
-This warning is expected and cannot be removed, because `eufy-security-client` still requires `RSA_PKCS1_PADDING` for Eufy cloud decryption. The Node.js security fix is intentionally reverted to keep the integration working.
-
-You can safely ignore this message; it does not indicate an error or security issue in your setup.
+The container no longer passes that flag. Instead, `eufy-security-client`'s embedded (pure-JS) PKCS#1
+implementation is enabled by default (`enableEmbeddedPKCS1Support: true`), so the integration works on
+Node 24+ without any Node override. You don't need to configure anything; to opt out, set
+`"enableEmbeddedPKCS1Support": false` in your config file.
 

--- a/docs/tryitout.md
+++ b/docs/tryitout.md
@@ -17,7 +17,7 @@ Options:
 ```
 
 ```shell
-node --security-revert=CVE-2023-46809 dist/bin/server.js -v -H 0.0.0.0
+node dist/bin/server.js -v -H 0.0.0.0
 ```
 
 Opens server on `ws://localhost:3000`.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build": "tsc -p .",
     "prepublishOnly": "rm -rf dist tsconfig.tsbuildinfo && npm run build",
     "build:ts": "tsc -p .",
-    "server": "node --security-revert=CVE-2023-46809 ./dist/bin/server.js -v -H 0.0.0.0",
+    "server": "node ./dist/bin/server.js -v -H 0.0.0.0",
     "client": "tsx ./src/bin/client.ts -v",
     "format": "prettier --write \"src/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\""

--- a/src/bin/server.ts
+++ b/src/bin/server.ts
@@ -65,6 +65,13 @@ const args = program.opts();
     return;
   }
 
+  // Use eufy-security-client's embedded (pure-JS) PKCS#1 v1.5 implementation so the
+  // P2P RSA handshake works without the Node `--security-revert=CVE-2023-46809` flag,
+  // which is no longer recognized on Node 24+ and aborts the process on startup.
+  if (config.enableEmbeddedPKCS1Support === undefined) {
+    config.enableEmbeddedPKCS1Support = true;
+  }
+
   if (args.verbose) {
     config.logging = {
       level: LogLevel.Debug,


### PR DESCRIPTION
Cause: The 3.0.0 release moved to Node 24, but the launch commands still passed --security-revert=CVE-2023-46809. Node 24 dropped that revert token, so it aborts on startup with exit code 12 before the app runs — Error: Attempt to revert an unknown CVE.

  Fix: Removed the now-invalid flag and switched to the library's built-in replacement, which eufy-security-client@4.0.0 provides for exactly this:
  
  1. docker/run.sh — removed the Node-version check_version/WORKAROUND_ISSUE_310 block and dropped the flag from the exec line.                                                                                                                   
  2. docker/run_dev.sh — same.
  3. package.json — server script no longer passes the flag.
  4. src/bin/server.ts — default config.enableEmbeddedPKCS1Support = true (when unset). This makes node-rsa use its pure-JS PKCS#1 v1.5 implementation (environment: "browser"), so the eufy P2P RSA handshake keeps working without needing any Node crypto override.

  Because the default lives in server.ts, it covers both the Docker (/dev/shm config) and bare-metal paths uniformly. Existing configs that explicitly set enableEmbeddedPKCS1Support are respected.

  Note: you'll want to rebuild/republish the Docker image for this to reach users — the dist/ and shell scripts both changed. Want me to bump the version and stage a commit?

  Sources:
  - nodejs/node#55628 — RSA_PKCS1_PADDING / security-revert CVE confusion
  - bropat/ioBroker.eusec#482 — same "unknown CVE" error on Node 22+
